### PR TITLE
feat!: rename `tryAcquire` to `acquireImmediately` + add `runImmedialely` method

### DIFF
--- a/docs/content/docs/api.md
+++ b/docs/content/docs/api.md
@@ -151,9 +151,10 @@ await lock.forceRelease()
 Create a lock.
 
 ```ts
-const lock = verrou.createLock('key')
-const lock = verrou.createLock('key', '5m')
-const lock = verrou.createLock('key', 30_000)
+const lockFactory = new LockFactory(redisStore())
+const lock1 = lockFactory.createLock('key')
+const lock2 = lockFactory.createLock('key', '5m')
+const lock3 = lockFactory.createLock('key', 30_000)
 ```
 
 First argument is the lock key. Second argument is optional and is the lock expiration time. By default, the lock expiration time is `30s`.
@@ -163,8 +164,9 @@ First argument is the lock key. Second argument is optional and is the lock expi
 Restore a lock. Useful when sharing a lock between multiple processes. See [Sharing a lock between multiple processes](./usage.md#sharing-a-lock-between-multiple-processes) for more details.
 
 ```ts
-const lock1 = verrou.createLock('key', 'owner')
-const lock2 = verrou.restoreLock(lock1.serialize())
+const lockFactory = new LockFactory(redisStore())
+const lock1 = lockFactory.createLock('key', 'owner')
+const lock2 = lockFactory.restoreLock(lock1.serialize())
 ```
 
 ## Verrou API

--- a/docs/content/docs/api.md
+++ b/docs/content/docs/api.md
@@ -43,23 +43,34 @@ Acquire the lock, run the callback, and release the lock.
 
 ```ts
 const lock = verrou.createLock('key')
-await lock.run({ retry: { timeout: '1000ms' } }, async () => {
+await lock.run(() => {
+  // do something
+})
+```
+
+### `runImmediately`
+
+Same as `run`, but try to acquire the lock immediately ( without retrying ). If the lock is already acquired, it will throws a `E_LOCK_ALREADY_ACQUIRED` error.
+
+```ts
+const lock = verrou.createLock('key')
+await lock.runImmediately(async () => {
   // do something
 })
 ```
 
 Accept an optional object with the same properties as `acquire`.
 
-### `tryAcquire`
+### `acquireImmediately`
 
-Try to acquire the lock immediately. If the lock is already acquired, it will throws a `E_LOCK_ALREADY_ACQUIRED` error.
+Try to acquire the lock immediately ( without retrying ). If the lock is already acquired, it will throws a `E_LOCK_ALREADY_ACQUIRED` error.
 
 ```ts
 import { errors } from '@verrou/core'
 
 const lock = verrou.createLock('key')
 try {
-  await lock.tryAcquire()
+  await lock.acquireImmediately()
 } catch (err) {
   if (err instanceof E_LOCK_ALREADY_ACQUIRED) {
 


### PR DESCRIPTION
- `tryAcquire` is now `acquireImmediately`
- Add a `runImmediately` method

because `tryAcquire` was a naming a bit confusing. 