### PR TITLE
refactor!: do not throw anymore when cant acquire a lock

### DIFF
--- a/docs/content/docs/introduction.md
+++ b/docs/content/docs/introduction.md
@@ -36,16 +36,13 @@ const verrou = new Verrou({
 
 ```ts
 // title: Manual lock
-import { Verrou, E_LOCK_TIMEOUT } from '@verrou/core'
+import { Verrou } from '@verrou/core'
 
 const lock = verrou.createLock('my-resource')
+const acquired = await lock.acquire()
+
 try {
-  await lock.acquire()
   await doSomething()
-} catch (error) {
-  if (error instanceof E_LOCK_TIMEOUT) {
-    // handle timeout
-  }
 } finally {
   await lock.release()
 }

--- a/packages/verrou/package.json
+++ b/packages/verrou/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.529.1",
+    "@japa/expect-type": "2.0.1",
     "@types/better-sqlite3": "^7.6.9",
     "@types/pg": "^8.11.2",
     "@types/proper-lockfile": "^4.1.4",

--- a/packages/verrou/src/errors.ts
+++ b/packages/verrou/src/errors.ts
@@ -1,18 +1,10 @@
 import { createError } from '@poppinss/utils'
 
 /**
- * Thrown when the lock is not acquired in the allotted time
- */
-export const E_LOCK_TIMEOUT = createError(
-  `Lock was not acquired in the allotted time`,
-  'E_LOCK_TIMEOUT',
-)
-
-/**
  * Thrown when user tries to update/release/extend a lock that is not acquired by them
  */
 export const E_LOCK_NOT_OWNED = createError(
-  'Looks like you are trying to update a lock that is not acquired by you',
+  'Looks like you are trying to update or release a lock that is not acquired by you',
   'E_LOCK_NOT_OWNED',
 )
 
@@ -22,12 +14,4 @@ export const E_LOCK_NOT_OWNED = createError(
 export const E_LOCK_STORAGE_ERROR = createError<[{ message: string }]>(
   'Lock storage error: %s',
   'E_LOCK_STORAGE_ERROR',
-)
-
-/**
- * Thrown when user tries to acquire a lock that is already acquired by someone else
- */
-export const E_LOCK_ALREADY_ACQUIRED = createError(
-  'Lock is already acquired',
-  'E_LOCK_ALREDY_ACQUIRED',
 )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,9 @@ importers:
       '@aws-sdk/client-dynamodb':
         specifier: ^3.529.1
         version: 3.529.1
+      '@japa/expect-type':
+        specifier: 2.0.1
+        version: 2.0.1(@japa/runner@3.1.1)
       '@types/better-sqlite3':
         specifier: ^7.6.9
         version: 7.6.9


### PR DESCRIPTION
this PR changes a crucial element of Verrou that simplifies the control flow. Previously, the `acquire`, `run`, `acquireImmediately` etc. methods threw an `E_LOCK_TIMEOUT` error if the lock could not be acquired

this sometimes made the flow a little complicated and not super readable :

```ts
try {
	await lock.acquireImmediately() 
	await criticalCode()
	return 'Order processed successfully'
} catch (err) {
	if (err instanceof errors.E_LOCK_ALREADY_ACQUIRED) {
		return 'Order is already being processed'
	}
} finally { 
	await lock.release()
}
```

Now, the methods will simply return a boolean to indicate whether the lock has been acquired or not. Example with `acquire` and `acquireImmediately`.

```ts
const acquired = await lock.acquireImmediately()
if (!acquired) return 'Order is already being processed'

try {	
	await criticalCode()
} finally {
	lock.release()
}
```

much simpler and easier to read this way.

for `run` and `runImmediately` it's a bit different. The functions now return tuples. Before, you had to do it like this: 

```ts
try {
	const result = await lock.run(() => {
		return await criticalCode()
	})
	
	return 'Order processed successfully'
} catch (err) {
	if (err instanceof errors.E_LOCK_ALREADY_ACQUIRED) {
	   return 'Couldnt acquire the lock'
	}
}
```

And now, with the new version :

```ts
const [executed, result] = await lock.run(() => {
  return await criticalCode()
})

if (executed) return 'Order processed successfully'
return 'Couldnt acquire the lock'
```