### PR TITLE
Clarify getRemainingTime description

### DIFF
--- a/docs/content/docs/api.md
+++ b/docs/content/docs/api.md
@@ -131,12 +131,13 @@ Argument is optional and defaults to the lock expiration time.
 
 ### `getRemainingTime`
 
-Get the remaining time before the lock expires.
+Get the remaining time in milliseconds before the lock expires.
 
 ```ts
 const lock = verrou.createLock('key', '10s')
 await lock.acquire()
 
+// returns remaining time for the lock in milliseconds
 const remainingTime = lock.getRemainingTime()
 ```
 

--- a/packages/verrou/src/lock.ts
+++ b/packages/verrou/src/lock.ts
@@ -174,7 +174,7 @@ export class Lock {
   }
 
   /**
-   * Get the remaining time before the lock expires
+   * Get the remaining time in milliseconds before the lock expires
    */
   getRemainingTime() {
     if (this.#expirationTime === null) return null


### PR DESCRIPTION
I've stumbled upon missing description for this method and it was unclear whether it is seconds or milliseconds (since extend uses `Duration`, while this method uses `number`). I think clarification of this would be good.